### PR TITLE
Add PHP 7.2 support to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "lizardmedia/module-varnish-warmer",
     "description": "Varnish Cache Warmer Magento2 module by Lizard Media",
     "require": {
-        "php": "~7.1.0",
+        "php": "~7.1.0 || ~7.2.0",
         "stil/curl-easy": "^1.1",
         "magento/framework": "101.0.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "require": {
         "php": "~7.1.0 || ~7.2.0",
         "stil/curl-easy": "^1.1",
-        "magento/framework": "101.0.*"
+        "magento/framework": "^102"
     },
     "type": "magento2-module",
-    "version": "1.0.7.2",
+    "version": "1.0.7.3",
     "license": [
         "MIT"
     ],

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "magento/framework": "101.0.*"
     },
     "type": "magento2-module",
-    "version": "1.0.7",
+    "version": "1.0.7.2",
     "license": [
         "MIT"
     ],


### PR DESCRIPTION
Currently, the composer.json version constraint does not allow this module to be used on Magento 2.3.x using PHP 7.2. Please consider this PR.