### PR TITLE
fix header syntax for purging

### DIFF
--- a/Model/QueueHandler/VarnishUrlPurger.php
+++ b/Model/QueueHandler/VarnishUrlPurger.php
@@ -140,10 +140,10 @@ class VarnishUrlPurger extends AbstractQueueHandler implements VarnishUrlPurgerI
     private function buildHeaders(): array
     {
         $headers = [];
-        $headers[] = 'X-Magento-Tags-Pattern: .*';
+        $headers['X-Magento-Tags-Pattern'] = '.*';
         if ($this->purgingConfigProvider->isPurgeCustomHostEnabled()
             && $this->purgingConfigProvider->getAdditionalHostForHeader()) {
-            $headers[] = "Host: {$this->purgingConfigProvider->getAdditionalHostForHeader()}";
+            $headers['Host'] = $this->purgingConfigProvider->getAdditionalHostForHeader();
         }
         return $headers;
     }


### PR DESCRIPTION
The header array should be key value pairs. Currently purges get 400 errors due to the tag not being set in the header.