### PR TITLE
PHP 7.4 compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "lizardmedia/module-varnish-warmer",
     "description": "Varnish Cache Warmer Magento2 module by Lizard Media",
     "require": {
-        "php": "~7.1.0|~7.2.0|~7.3.0",
+        "php": ">=7.1.0",
         "react/http-client": "^0.5.9",
         "magento/framework": ">=102.0"
     },


### PR DESCRIPTION
Hello,

Magento 2.4.x is now compatible with PHP 7.4 https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html#php

I've run locally and in magento cloud, and it seems to work seamlessly.

Regards